### PR TITLE
add help message

### DIFF
--- a/src/cmd_definitions.c
+++ b/src/cmd_definitions.c
@@ -8,10 +8,12 @@
 #define COUNT_OF(arr) (sizeof(arr) / sizeof(arr[0]))
 
 const cmd_definition cmd_definitions[] = {
-    {.name = "destroy", .arg_count = 0, .executor = &cmd_destroy},
-    {.name = "launch", .arg_count = 1, .executor = &cmd_launch},
-    {.name = "reboot", .arg_count = 0, .executor = &cmd_reboot},
-    {.name = "screen", .arg_count = 1, .executor = &cmd_screen}};
+    {.name = "help", .description = "Display this help screen", .arg_count = 0, .executor = &cmd_help},
+    {.name = "destroy", .description = "Kill all running applications", .arg_count = 0, .executor = &cmd_destroy},
+    {.name = "launch", .description = "Launch an app by Title ID", .arg_count = 1, .executor = &cmd_launch},
+    {.name = "reboot", .description = "Reboot the console", .arg_count = 0, .executor = &cmd_reboot},
+    {.name = "screen", .description = "Turn the screen on or off", .arg_count = 1, .executor = &cmd_screen}
+};
 
 const cmd_definition *cmd_get_definition(char *cmd_name) {
   for (unsigned int i = 0; i < COUNT_OF(cmd_definitions); i++) {
@@ -21,6 +23,28 @@ const cmd_definition *cmd_get_definition(char *cmd_name) {
   }
 
   return NULL;
+}
+
+void cmd_help(char **arg_list, size_t arg_count, char *res_msg) {
+  char buf[2000] = {0};
+  int longest_cmd = 0;
+
+  for (int i = 0; i < COUNT_OF(cmd_definitions); ++i) {
+    int cmd_length = strlen(cmd_definitions[i].name);
+
+    if (cmd_length > longest_cmd) {
+      longest_cmd = cmd_length;
+    }
+  }
+
+  sprintf(buf, "%-*s\t\t%s\n", longest_cmd, "Command", "Description");
+  strcpy(res_msg, buf);
+
+  for (int i = 0; i < COUNT_OF(cmd_definitions); ++i) {
+    sprintf(buf, "%-*s\t\t%s\n", longest_cmd, cmd_definitions[i].name, cmd_definitions[i].description);
+    strcat(res_msg, buf);
+  }
+
 }
 
 void cmd_destroy(char **arg_list, size_t arg_count, char *res_msg) {

--- a/src/cmd_definitions.h
+++ b/src/cmd_definitions.h
@@ -6,11 +6,13 @@ typedef void cmd_executor(char **arg_list, size_t arg_count, char *res_msg);
 
 typedef struct {
     char  *name;
+    char  *description;
     size_t arg_count;
     cmd_executor *executor;
 } cmd_definition;
 
 const cmd_definition *cmd_get_definition(char *cmd_name);
+void cmd_help(char **arg_list, size_t arg_count, char *res_msg);
 void cmd_destroy(char **arg_list, size_t arg_count, char *res_msg);
 void cmd_launch(char **arg_list, size_t arg_count, char *res_msg);
 void cmd_reboot(char **arg_list, size_t arg_count, char *res_msg);


### PR DESCRIPTION
essentially just #12

the output has been streamlined and doesn't contain info like argument count or type
![image](https://user-images.githubusercontent.com/15076013/114315941-9d399000-9b01-11eb-8e29-bb6d7568d327.png)

There is a problem though (which also existed with the previous implementation
currently we are given no more than a 60 char array which means we are essentially causing a stack overflow and potentially causing harm elsewhere
https://github.com/devnoname120/vitacompanion/blob/7dc195d5ecbf73133213a01cdd19f31a4b573e6b/src/cmd.c#L68

A simply solutio would be to increase res_msg and use strn* family of functions to ensure we do not overflow
but this results in problems in the future if more commands are going to be added so perhaps having the commands allocate what they need to the heap, return the pointer and free it after we are done sending is the better way?
